### PR TITLE
Enhance music generation with transformer model

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ The project is structured into several key scripts:
 - `validations/midi_to_human_readable.py`: Converts MIDI files into a human-readable format for debugging and understanding the MIDI data structure.
 - `validations/check_npz.py`: Converts chosen .npz file into text files for debugging.
 - `validations/intensity_profile.py`: Examines intensity of piece(s) as a function of velocity, tempo, tension, and pitch aggregation. For research purposes.
-- `train_model.py`: Trains a multi-output RNN model on the processed MIDI data, capable of predicting pitch, velocity, and time delta for the next event in a sequence.
-- `rnn_model.py`: Defines the RNN model architecture used for training in `train_model.py`.
+- `train_model.py`: Trains either an RNN or Transformer model on the processed MIDI data, capable of predicting pitch, velocity, and time delta for the next event in a sequence.
+- `rnn_model.py`: Defines the GRU-based architecture.
+- `transformer_model.py`: Provides a Transformer architecture for advanced training.
 - `generate.py`: Uses the trained model(s) to generate new music sequences based on a random seed or a given input sequence.
 - `rules/...`: These are "dissolvable" rules which aid music generation. They are dissolvable because they will eventually not be invoked as training improves.
 - `seeds/...`: These are different starting sequences that can be invoked.
@@ -56,10 +57,15 @@ The project is structured into several key scripts:
 
 ### Training the Model
 
-1. After preprocessing, use `train_model.py` to train the RNN model:
+1. After preprocessing, use `train_model.py` to train a model. The script now
+   supports an optional Transformer architecture:
 
     ```
+    # Train GRU-based model
     python train_model.py
+
+    # Train Transformer model
+    python train_model.py --model_type transformer
     ```
 
 2. Trained models are saved in the `./outputs/models` directory.

--- a/src/models/transformer_model.py
+++ b/src/models/transformer_model.py
@@ -1,0 +1,60 @@
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.layers import (Input, Dense, Dropout, LayerNormalization,
+                                     MultiHeadAttention, Add, Flatten)
+from tensorflow.keras.models import Model
+
+
+def positional_encoding(length, depth):
+    depth = depth // 2
+    positions = np.arange(length)[:, np.newaxis]
+    depths = np.arange(depth)[np.newaxis, :] / depth
+    angle_rates = 1 / (10000**depths)
+    angle_rads = positions * angle_rates
+    pos_encoding = np.concatenate([np.sin(angle_rads), np.cos(angle_rads)], axis=-1)
+    return tf.cast(pos_encoding, dtype=tf.float32)
+
+
+def transformer_block(x, num_heads, ff_dim, dropout_rate):
+    attn_output = MultiHeadAttention(num_heads=num_heads, key_dim=ff_dim)(x, x)
+    attn_output = Dropout(dropout_rate)(attn_output)
+    x = Add()([x, attn_output])
+    x = LayerNormalization(epsilon=1e-6)(x)
+
+    ffn_output = Dense(ff_dim * 2, activation='relu')(x)
+    ffn_output = Dense(ff_dim)(ffn_output)
+    ffn_output = Dropout(dropout_rate)(ffn_output)
+    x = Add()([x, ffn_output])
+    x = LayerNormalization(epsilon=1e-6)(x)
+    return x
+
+
+def build_transformer_model(
+    input_shape,
+    num_heads=4,
+    ff_dim=128,
+    num_layers=4,
+    dropout_rate=0.1,
+    pitch_range=128,
+    velocity_range=128,
+    time_delta_range=3500,
+):
+    """Build a simple Transformer-based model for music generation."""
+    seq_len, num_features = input_shape
+    inputs = Input(shape=input_shape)
+
+    x = Dense(ff_dim)(inputs)
+    x += positional_encoding(seq_len, ff_dim)
+
+    for _ in range(num_layers):
+        x = transformer_block(x, num_heads, ff_dim, dropout_rate)
+
+    x = Flatten()(x)
+
+    note_event_output = Dense(2, activation='softmax', name='note_event_output')(x)
+    pitch_output = Dense(pitch_range, activation='softmax', name='pitch_output')(x)
+    velocity_output = Dense(velocity_range, activation='softmax', name='velocity_output')(x)
+    time_delta_output = Dense(time_delta_range, activation='softmax', name='time_delta_output')(x)
+
+    model = Model(inputs=inputs, outputs=[note_event_output, pitch_output, velocity_output, time_delta_output])
+    return model


### PR DESCRIPTION
## Summary
- add a simple Transformer architecture for training
- support selecting RNN or Transformer models in the training script
- improve generation with constrained sampling and pitch range control
- update docs with new training options

## Testing
- `python -m py_compile src/models/transformer_model.py src/training/train_model.py src/generation/generate.py`
- `python -m py_compile $(git ls-files 'src/**/*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844d701c7108328a84a120ca965fb73